### PR TITLE
feat: implement dark-light mode toggle with user preference persistence (Flutter)

### DIFF
--- a/unitrade/lib/screens/profile/viewmodels/theme_viewmodel.dart
+++ b/unitrade/lib/screens/profile/viewmodels/theme_viewmodel.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:unitrade/utils/theme_provider.dart';
+
+class ThemeViewModel {
+  final BuildContext context;
+  ThemeViewModel(this.context);
+
+  ThemeModeType get selectedThemeMode =>
+      Provider.of<ThemeProvider>(context, listen: false).selectedThemeMode;
+
+  bool get isTimeBased =>
+      Provider.of<ThemeProvider>(context, listen: false).isTimeBased;
+
+  void setThemeMode(ThemeModeType mode) {
+    Provider.of<ThemeProvider>(context, listen: false).setThemeMode(mode);
+  }
+
+  void toggleTimeBasedTheme(bool value) {
+    Provider.of<ThemeProvider>(context, listen: false)
+        .toggleTimeBasedTheme(value);
+  }
+}

--- a/unitrade/lib/screens/profile/views/profile_view.dart
+++ b/unitrade/lib/screens/profile/views/profile_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:unitrade/screens/home/views/nav_bar_view.dart';
+import 'package:unitrade/screens/profile/views/theme_view.dart';
 import 'package:unitrade/utils/firebase_service.dart';
 
 class ProfileView extends StatelessWidget {
@@ -24,11 +25,10 @@ class ProfileView extends StatelessWidget {
       ),
       body: Column(
         children: [
-          // Expanded widget to center the content in the middle
           Expanded(
             child: Center(
               child: Column(
-                mainAxisSize: MainAxisSize.min, // Centers the column's content
+                mainAxisSize: MainAxisSize.min,
                 children: [
                   Text(
                     'TODO: Implement Profile View',
@@ -40,6 +40,19 @@ class ProfileView extends StatelessWidget {
                   const SizedBox(height: 16),
                 ],
               ),
+            ),
+          ),
+          // Button to navigate to the theme settings
+          Padding(
+            padding: const EdgeInsets.only(bottom: 16.0),
+            child: ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (context) => const ThemeView()),
+                );
+              },
+              child: const Text('Theme Settings'),
             ),
           ),
           // Logout button at the bottom

--- a/unitrade/lib/screens/profile/views/theme_view.dart
+++ b/unitrade/lib/screens/profile/views/theme_view.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:unitrade/screens/home/views/nav_bar_view.dart';
+import 'package:unitrade/screens/profile/viewmodels/theme_viewmodel.dart';
+import 'package:unitrade/utils/app_colors.dart';
+import 'package:unitrade/utils/theme_provider.dart';
+
+class ThemeView extends StatefulWidget {
+  const ThemeView({super.key});
+
+  @override
+  ThemeViewState createState() => ThemeViewState();
+}
+
+class ThemeViewState extends State<ThemeView> {
+  late ThemeViewModel _viewModel;
+
+  @override
+  void initState() {
+    super.initState();
+    _viewModel = ThemeViewModel(context);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    bool isTimeBased = _viewModel.isTimeBased;
+
+    return Scaffold(
+      bottomNavigationBar: const NavBarView(initialIndex: 4),
+      appBar: AppBar(
+        elevation: 1.0,
+        title: Text(
+          'Theme Settings',
+          style: GoogleFonts.urbanist(
+            fontSize: 16,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        centerTitle: true,
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            const Text("Choose Theme Mode"),
+            const SizedBox(height: 20),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: [
+                Column(
+                  children: [
+                    const Icon(Icons.wb_sunny, size: 40),
+                    Radio<ThemeModeType>(
+                      value: ThemeModeType.light,
+                      groupValue: _viewModel.selectedThemeMode,
+                      onChanged: isTimeBased
+                          ? null // Disable when time-based is ON
+                          : (ThemeModeType? value) {
+                              if (value != null) {
+                                _viewModel.setThemeMode(value);
+                                setState(() {});
+                              }
+                            },
+                    ),
+                    const Text("Light"),
+                  ],
+                ),
+                Column(
+                  children: [
+                    const Icon(Icons.nights_stay, size: 40),
+                    Radio<ThemeModeType>(
+                      value: ThemeModeType.dark,
+                      groupValue: _viewModel.selectedThemeMode,
+                      onChanged: isTimeBased
+                          ? null // Disable when time-based is ON
+                          : (ThemeModeType? value) {
+                              if (value != null) {
+                                _viewModel.setThemeMode(value);
+                                setState(() {});
+                              }
+                            },
+                    ),
+                    const Text("Dark"),
+                  ],
+                ),
+              ],
+            ),
+            const SizedBox(height: 20),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  "Automatic time-aware (Sunrise/Sunset)",
+                  style: GoogleFonts.urbanist(
+                    color: isTimeBased
+                        ? Theme.of(context).textTheme.bodyLarge!.color
+                        : AppColors.light400,
+                  ),
+                ),
+                Switch(
+                  value: isTimeBased,
+                  onChanged: (bool value) {
+                    _viewModel.toggleTimeBasedTheme(value);
+                    setState(() {});
+                  },
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/unitrade/lib/screens/upload/viewmodels/upload_product_viewmodel.dart
+++ b/unitrade/lib/screens/upload/viewmodels/upload_product_viewmodel.dart
@@ -96,7 +96,7 @@ class UploadProductViewModel with ChangeNotifier {
 
     try {
       var response = await http.put(
-        Uri.parse(ApiConfig.apiUrl),
+        Uri.parse(ApiConfig.apiTestUrl),
         body: body,
         headers: headers,
       );

--- a/unitrade/lib/utils/theme_provider.dart
+++ b/unitrade/lib/utils/theme_provider.dart
@@ -1,54 +1,74 @@
 import 'dart:async';
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:light_sensor/light_sensor.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:unitrade/utils/app_colors.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+// Theme modes
+enum ThemeModeType { light, dark }
 
 class ThemeProvider extends ChangeNotifier {
+  // Variables for time-based theme
   late ThemeData _themeData;
-  static const double _brightThreshold = 100.0;
   Timer? _timer;
   int _lastCheckedHour = -1;
+  bool _isTimeBased = true;
 
+  // Variables for manual theme
+  ThemeModeType _selectedThemeMode = ThemeModeType.light;
+
+  // Constructor
   ThemeProvider() {
-    // Default theme
     _themeData = lightTheme;
-
-    // Light sensor
-    // _initializeLightSensor();
-
-    // Time based theme
-    _initializeByTime();
+    _loadThemePreference();
     _startListening();
   }
 
+  // Getters
   ThemeData get themeData => _themeData;
+  bool get isTimeBased => _isTimeBased;
+  ThemeModeType get selectedThemeMode => _selectedThemeMode;
 
-  // ignore: unused_element
-  void _initializeLightSensor() async {
-    bool hasSensor = await LightSensor.hasSensor();
-    if (hasSensor) {
-      LightSensor.luxStream().listen((lux) {
-        _updateThemeByLightLevel(lux);
-      });
+  /* --------- Methods for theme switching --------- */
+
+  void setThemeMode(ThemeModeType mode) {
+    _selectedThemeMode = mode;
+    _isTimeBased = false;
+    _saveThemePreference(getThemeModeString());
+    _applyThemeMode();
+  }
+
+  String getThemeModeString() {
+    if (_selectedThemeMode == ThemeModeType.light) {
+      return 'light';
     } else {
-      if (kDebugMode) {
-        print("Device doesn't have a light sensor.");
-      }
+      return 'dark';
     }
   }
 
-  void _updateThemeByLightLevel(int lux) {
-    if (lux > _brightThreshold && _themeData != lightTheme) {
-      _themeData = lightTheme;
-      notifyListeners();
-    } else if (lux <= _brightThreshold && _themeData != darkTheme) {
-      _themeData = darkTheme;
-      notifyListeners();
+  Future<void> toggleTimeBasedTheme(bool value) async {
+    _isTimeBased = value;
+    if (_isTimeBased) {
+      await _saveThemePreference(null);
+      _initializeByTime();
+    } else {
+      await _saveThemePreference(getThemeModeString());
+      _applyThemeMode();
     }
+    notifyListeners();
   }
+
+  void _applyThemeMode() {
+    if (_selectedThemeMode == ThemeModeType.light) {
+      _themeData = lightTheme;
+    } else if (_selectedThemeMode == ThemeModeType.dark) {
+      _themeData = darkTheme;
+    }
+    notifyListeners();
+  }
+
+  /* --------- Methods for time-based theme --------- */
 
   void _initializeByTime() {
     final hour = DateTime.now().hour;
@@ -63,14 +83,49 @@ class ThemeProvider extends ChangeNotifier {
     _timer?.cancel();
     _timer = Timer.periodic(const Duration(seconds: 15), (timer) {
       final now = DateTime.now();
-      if (now.hour != _lastCheckedHour) {
+      if (now.hour != _lastCheckedHour && _isTimeBased) {
         _lastCheckedHour = now.hour;
         _initializeByTime();
       }
     });
   }
+
+  /* --------- Methods for saving/loading theme preference --------- */
+
+  Future<void> _loadThemePreference() async {
+    final prefs = await SharedPreferences.getInstance();
+    final themePreference = prefs.getString('theme');
+    if (kDebugMode) {
+      print('Theme preference: $themePreference');
+    }
+
+    if (themePreference == null) {
+      // If theme is null, it means the user prefers time-based switching
+      _isTimeBased = true;
+      _initializeByTime();
+    } else {
+      // Apply the saved manual theme
+      _isTimeBased = false;
+      if (themePreference == 'light') {
+        _selectedThemeMode = ThemeModeType.light;
+      } else if (themePreference == 'dark') {
+        _selectedThemeMode = ThemeModeType.dark;
+      }
+      _applyThemeMode();
+    }
+  }
+
+  Future<void> _saveThemePreference(String? preference) async {
+    final prefs = await SharedPreferences.getInstance();
+    if (preference == null) {
+      await prefs.remove('theme');
+    } else {
+      await prefs.setString('theme', preference);
+    }
+  }
 }
 
+// Themes
 final ThemeData lightTheme = ThemeData(
   brightness: Brightness.light,
   colorScheme: const ColorScheme.light(surface: AppColors.primaryNeutral),

--- a/unitrade/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/unitrade/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -12,6 +12,7 @@ import firebase_auth
 import firebase_core
 import firebase_storage
 import path_provider_foundation
+import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseFirestorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseFirestorePlugin"))
@@ -21,4 +22,5 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   FLTFirebaseStoragePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseStoragePlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }

--- a/unitrade/pubspec.lock
+++ b/unitrade/pubspec.lock
@@ -536,6 +536,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.2"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: "746e5369a43170c25816cc472ee016d3a66bc13fcf430c0bc41ad7b4b2922051"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: "3b9febd815c9ca29c9e3520d50ec32f49157711e143b7a4ca039eb87e8ade5ab"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.3"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "07e050c7cd39bad516f8d64c455f04508d09df104be326d8c02551590a0d513d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.3"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: d2ca4132d3946fec2184261726b355836a82c33d7d5b67af32692aff18a4684e
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/unitrade/pubspec.yaml
+++ b/unitrade/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
   intl: ^0.19.0
   device_info_plus: ^10.0.1
   http: ^1.2.2
+  shared_preferences: ^2.3.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This pull request introduces a new theme management feature, adds a theme settings view, and includes other minor updates. The most important changes include the creation of a `ThemeViewModel` for managing theme states, the addition of a `ThemeView` for user interaction with theme settings, and updates to the `ThemeProvider` for handling theme preferences.

### Theme Management:

* `unitrade/lib/screens/profile/viewmodels/theme_viewmodel.dart`: Created `ThemeViewModel` to manage theme states and interactions using the `ThemeProvider`.

* `unitrade/lib/screens/profile/views/theme_view.dart`: Added `ThemeView` for users to change theme settings, including light, dark, and automatic time-based themes.

* `unitrade/lib/utils/theme_provider.dart`: Updated `ThemeProvider` to manage theme modes with `SharedPreferences`, including methods for saving and loading theme preferences, and toggling time-based themes. 

### UI Enhancements:

* `unitrade/lib/screens/profile/views/profile_view.dart`: Added a button in `ProfileView` to navigate to the new `ThemeView` for theme settings.

### Minor Updates:

* `unitrade/lib/screens/upload/viewmodels/upload_product_viewmodel.dart`: Updated API URL for testing purposes.

* `unitrade/pubspec.yaml`: Added `shared_preferences` dependency.